### PR TITLE
feat: keepalive configuration in Server resource

### DIFF
--- a/api/v1/server_types.go
+++ b/api/v1/server_types.go
@@ -51,6 +51,9 @@ type ServerSpec struct {
 
 	Endpoint string `json:"endpoint,omitempty"`
 
+	// KeepAlive duration in seconds, defaults to 0 (disabled)
+	KeepAlive int32 `json:"keepAlive,omitempty"`
+
 	Expose Expose `json:"expose,omitempty"`
 
 	DNS DNS `json:"dns,omitempty"`

--- a/config/crd/bases/wireguard.kloudlite.github.com_servers.yaml
+++ b/config/crd/bases/wireguard.kloudlite.github.com_servers.yaml
@@ -80,6 +80,10 @@ spec:
               ip:
                 default: 10.13.0.1
                 type: string
+              keepAlive:
+                description: KeepAlive duration in seconds, defaults to 0 (disabled)
+                format: int32
+                type: integer
               peers:
                 items:
                   properties:

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -221,6 +221,7 @@ func (r *ServerReconciler) createDeployment(check *reconciler.Check[*v1.Server],
 		ServerPrivateKey: *obj.Spec.PrivateKey,
 		PodCIDR:          r.env.PodCIDR,
 		Peers:            obj.Spec.Peers,
+		KeepAlive:        obj.Spec.KeepAlive,
 	})
 	if err != nil {
 		return check.Failed(err)

--- a/internal/templates/types.go
+++ b/internal/templates/types.go
@@ -11,6 +11,7 @@ type ParamsWgServerConf struct {
 	PodCIDR          string
 	WithUDP2Raw      bool
 	Peers            []v1.Peer
+	KeepAlive        int32
 }
 
 type ParamsWgPeerConf struct {

--- a/internal/templates/wg-server.conf.tpl
+++ b/internal/templates/wg-server.conf.tpl
@@ -19,6 +19,9 @@ PublicKey = {{ $peer.PublicKey }}
 AllowedIPs = {{ $peer.IP }}/32
 {{- if $peer.Endpoint }}
 Endpoint = {{$peer.Endpoint}}
+{{- if $gt $.KeepAlive 0 }}
+PersistentKeepalive = {{$.KeepAlive}}
+{{- end }}
 {{- end }}
 {{- end}}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a keep-alive duration (in seconds) for servers, allowing users to enable or disable persistent keep-alive settings in server configurations.
  * The keep-alive setting is now available as an optional field when creating or updating server resources.

* **Bug Fixes**
  * Server configuration templates now correctly include the keep-alive value for peers when an endpoint is defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->